### PR TITLE
Object permanence draft

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pytest
 matplotlib
 enum34
+numpy

--- a/src/python/tests/motor_test.py
+++ b/src/python/tests/motor_test.py
@@ -18,7 +18,7 @@ commands are skipped to save time. `test_import_*` should both fail in this mode
 from __future__ import division
 from utils.constants import MAX_MOTOR_SPEED, PIXY_RCS_PAN_CHANNEL
 import logging
-from utils.bot_logging import get_logger_name
+from utils.bot_logging import set_log_level
 import pytest
 import time
 
@@ -50,14 +50,18 @@ class DummyPixy(Dummy):
         assert isinstance(channel_arg, int)
 
 
+@pytest.mark.xfail
 def test_import_motors():
     from pololu_drv8835_rpi import motors
 
+
+@pytest.mark.xfail
 def test_import_pixy():
     from pixy import pixy
 
 
-logger = logging.getLogger(get_logger_name(logging.DEBUG))
+logger = logging.getLogger(__name__)
+set_log_level(logging.DEBUG)
 try:
     from pololu_drv8835_rpi import motors
 except:

--- a/src/python/tests/vision_test.py
+++ b/src/python/tests/vision_test.py
@@ -2,14 +2,8 @@
 
 from __future__ import division
 import logging
-from random import Random
-from copy import copy
 
 import pytest
-import numpy as np
-import matplotlib
-matplotlib.use('Agg')
-from matplotlib import pyplot as plt
 
 from utils import vision
 from utils.bot_logging import set_log_level
@@ -18,10 +12,6 @@ logger = logging.getLogger(__name__)
 set_log_level(logging.DEBUG)
 
 SMALL_NUMBER = 0.01
-
-TARGET_SIGMA = 0.01
-TARGET_CONFIDENCE = 0.95
-REPLICATES = 1000
 
 
 # CONVENIENCE CLASSES
@@ -123,10 +113,8 @@ def test_near_equality_signature():
 
 
 def test_near_equality_power():
-    block = vision.GenericBlock(1, 0, 0, 1, 1)
-    result = vision.near_equality_accuracy_for_sigma(block, TARGET_SIGMA, REPLICATES)
-
-    assert result > TARGET_CONFIDENCE
+    result = vision.near_equality_accuracy_for_sigma(vision.TARGET_SIGMA, vision.REPLICATES)
+    assert result > vision.TARGET_CONFIDENCE
 
 
 def test_nearly_equal_pairs_combinations():
@@ -181,7 +169,10 @@ def test_merge_blocks():
     assert len(new_blocks) == 2
     assert block4 in new_blocks
     assert vision.GenericBlock.merge_blocks(block1, block2, block3) in new_blocks
+
+
 # SCENE TESTS
+
 
 def test_merge_scene():
     factory = BlockFactory()

--- a/src/python/tests/vision_test.py
+++ b/src/python/tests/vision_test.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python
+
+from __future__ import division
+import logging
+from random import Random
+from copy import copy
+
+import pytest
+import numpy as np
+import matplotlib
+matplotlib.use('Agg')
+from matplotlib import pyplot as plt
+
+from utils import vision
+from utils.bot_logging import set_log_level
+
+logger = logging.getLogger(__name__)
+set_log_level(logging.DEBUG)
+
+SMALL_NUMBER = 0.01
+
+TARGET_SIGMA = 0.01
+TARGET_CONFIDENCE = 0.95
+REPLICATES = 1000
+
+
+# CONVENIENCE CLASSES
+
+
+class BlockFactory(object):
+    def __init__(self, signature=1, width=1.0, height=1.0):
+        self.signature = signature
+        self.width = width
+        self.height = height
+
+    def block(self, x=0.0, y=0.0, width=None, height=None):
+        if width is None:
+            width = self.width
+        if height is None:
+            height = self.height
+        return vision.GenericBlock(self.signature, x, y, width, height)
+
+
+# GENERICBLOCK TESTS
+
+
+@pytest.mark.parametrize('bottom_left1,bottom_left2,expected', [
+    ((0, 0), (0, 0), 1),
+    ((0, 0), (0.5, 0), 0.5),
+    ((0, 0), (0.5, 0.5), 0.25),
+    ((0, 0), (2, 2), 0),
+    ((0, 0), (1, 0), 0)
+])
+def test_intersection_area(bottom_left1, bottom_left2, expected):
+    factory = BlockFactory()
+    block1, block2 = factory.block(*bottom_left1), factory.block(*bottom_left2)
+
+    assert block1.intersection_area(block2) == expected
+
+
+@pytest.mark.parametrize('bottom_left1,bottom_left2,expected', [
+    ((0, 0), (0, 0), 1),
+    ((0, 0), (0.5, 0), 0.5),
+    ((0, 0), (0.5, 0.5), 0.25),
+    ((0, 0), (2, 2), 0),
+    ((0, 0), (1, 0), 0)
+])
+def test_intersection_ppn(bottom_left1, bottom_left2, expected):
+    factory = BlockFactory()
+    block1, block2 = factory.block(*bottom_left1), factory.block(*bottom_left2)
+
+    assert block1.intersection_ppn(block2) == expected
+
+
+@pytest.mark.parametrize('bottom_left1,bottom_left2,expected', [
+    ((0, 0), (0.5, 0.5), True),
+    ((0, 0), (2, 2), False),
+    ((0, 0), (1, 0), False)
+])
+def test_intersects(bottom_left1, bottom_left2, expected):
+    factory = BlockFactory()
+    block1, block2 = factory.block(*bottom_left1), factory.block(*bottom_left2)
+
+    assert block1.intersects(block2) == expected
+
+
+@pytest.mark.parametrize('bottom_left1,bottom_left2,expected', [
+    ((0, 0), (SMALL_NUMBER, 0), True),
+    ((0, 0), (1, 1), False)
+])
+def test_nearly_equals(bottom_left1, bottom_left2, expected):
+    # todo: just test up to threshold sigma
+    factory = BlockFactory()
+    block1, block2 = factory.block(*bottom_left1), factory.block(*bottom_left2)
+
+    assert block1.nearly_equals(block2) == expected
+
+
+def test_merge_2_class():
+    factory = BlockFactory()
+    block1, block2 = factory.block(0, 0), factory.block(1, 1, 2, 2)
+
+    block3 = vision.GenericBlock.merge_blocks(block1, block2)
+
+    assert block3.x == 0.5
+    assert block3.y == 0.5
+    assert block3.width == 1.5
+    assert block3.height == 1.5
+
+
+def test_equality():
+    factory = BlockFactory()
+    assert factory.block() == factory.block()
+
+
+def test_near_equality_signature():
+    factory = BlockFactory()
+    block1 = factory.block()
+    block2 = factory.block()
+    block2.signature = 2
+
+    assert not block1.nearly_equals(block2)
+
+
+def test_near_equality_power():
+    block = vision.GenericBlock(1, 0, 0, 1, 1)
+    result = vision.near_equality_accuracy_for_sigma(block, TARGET_SIGMA, REPLICATES)
+
+    assert result > TARGET_CONFIDENCE
+
+
+def test_nearly_equal_pairs_combinations():
+    factory = BlockFactory()
+    block1, block2, block3 = factory.block(), factory.block(1, 1), factory.block()
+
+    pairs = vision.nearly_equal_pairs((block1, block2, block3))
+
+    assert len(pairs) == 1
+    pair = pairs.pop()
+    assert block1 in pair
+    assert block3 in pair
+
+
+def test_nearly_equal_pairs():
+    factory = BlockFactory()
+    block1, block2 = factory.block(), factory.block(SMALL_NUMBER, SMALL_NUMBER)
+    block3, block4 = factory.block(), factory.block(1, 1)
+
+    pairs = vision.nearly_equal_pairs((block1, block2), (block3, block4))
+
+    assert len(pairs) == 2
+    assert (block1, block3) in pairs
+    assert (block2, block3) in pairs
+
+
+def test_signature_not_equal():
+    block1 = vision.GenericBlock(0, 0, 0, 1, 1)
+    block2 = vision.GenericBlock(1, 0, 0, 1, 1)
+
+    assert block1.nearly_equals(block2) is False
+
+
+def test_merge_blocks_combinations():
+    factory = BlockFactory()
+    block1, block2, block3 = factory.block(), factory.block(1, 1), factory.block(SMALL_NUMBER, SMALL_NUMBER)
+
+    new_blocks = vision.merge_similar_blocks((block1, block2, block3))
+
+    assert len(new_blocks) == 2
+    assert block2 in new_blocks
+    assert vision.GenericBlock.merge_blocks(block1, block3) in new_blocks
+
+
+def test_merge_blocks():
+    factory = BlockFactory()
+    block1, block2 = factory.block(), factory.block(SMALL_NUMBER*2, SMALL_NUMBER*2)
+    block3, block4 = factory.block(SMALL_NUMBER, SMALL_NUMBER), factory.block(1, 1)
+
+    new_blocks = vision.merge_similar_blocks((block1, block2), (block3, block4))
+
+    assert len(new_blocks) == 2
+    assert block4 in new_blocks
+    assert vision.GenericBlock.merge_blocks(block1, block2, block3) in new_blocks
+# SCENE TESTS
+
+def test_merge_scene():
+    factory = BlockFactory()
+    block1, block2 = factory.block(), factory.block(1, 1)
+    block3, block4 = factory.block(SMALL_NUMBER, SMALL_NUMBER), factory.block(2, 2)
+    scene1 = vision.Scene((block1, block2))
+    scene2 = vision.Scene((block3, block4))
+
+    scene3 = scene1.merge(scene2)
+
+    assert isinstance(scene3, vision.Scene)
+    assert block2 in scene3.blocks
+    assert block4 in scene3.blocks
+    assert vision.GenericBlock.merge_blocks(block1, block3) in scene3.blocks
+
+
+def test_diff_scene_extra():
+    factory = BlockFactory()
+    block1, block2, block3 = factory.block(), factory.block(SMALL_NUMBER, SMALL_NUMBER), factory.block(1, 1)
+    scene1 = vision.Scene([block1])
+    scene2 = vision.Scene([block2, block3])
+
+    added, subtracted = scene1.diff(scene2)
+
+    assert len(subtracted) == 0
+    assert len(added) == 1
+    assert block3 in added
+
+
+def test_diff_scene_signature():
+    factory = BlockFactory()
+    block1 = factory.block()
+    block2 = factory.block()
+    block2.signature = 2
+
+    added, subtracted = vision.Scene([block1]).diff(vision.Scene([block2]))
+
+    assert len(added) == 1
+    assert block2 in added
+    assert len(subtracted) == 1
+    assert block1 in subtracted

--- a/src/python/utils/vision.py
+++ b/src/python/utils/vision.py
@@ -5,9 +5,6 @@ from copy import copy
 
 import numpy as np
 import networkx as nx
-import matplotlib
-matplotlib.use('TkAgg')
-from matplotlib import pyplot as plt
 
 
 SIMILARITY_THRESHOLD = 0.9
@@ -358,6 +355,8 @@ class Scene(object):
 # DIAGNOSTICS
 
 class BlockJitterer(object):
+    """Class for generating large numbers of very similar blocks"""
+
     def __init__(self, sigma, seed=1, constructor=GenericBlock):
         self.random = Random(seed)
         self.sigma = sigma
@@ -375,20 +374,32 @@ class BlockJitterer(object):
         return new_block
 
 
-def near_equality_accuracy_for_sigma(block, sigma, replicates):
+def near_equality_accuracy_for_sigma(sigma, replicates):
+    """For a given standard deviation, find the proportion of blocks correctly identified as nearly equal"""
+    block = GenericBlock(1, 0, 0, 1, 1)
     jitterer = BlockJitterer(sigma=sigma, seed=1)
     return sum(block.nearly_equals(jittered) for jittered in jitterer.jitter_blocks(block, replicates)) / replicates
 
 
+TARGET_SIGMA = 0.02
+TARGET_CONFIDENCE = 0.95
+REPLICATES = 500
+
+
 def plot_near_equality_power():
-    TARGET_SIGMA = 0.05
-    TARGET_CONFIDENCE = 0.95
-    REPLICATES = 500
+    """
+    This can certainly be done analytically, but numerically was easier.
 
-    block = GenericBlock(1, 0, 0, 1, 1)
+    Plot the proportion of blocks correctly identified as nearly equal, for varying amounts of noise (sigma).
 
+    We want the blue line to be passing above and to the right of the red/green cross (this is represented in the 
+    tests).
+
+    However, if we go too far in that direction, we will pick up a lot of false positives (there is currently no test 
+    for this).
+    """
     sigmas = np.linspace(0, TARGET_SIGMA * 2, 101, True)
-    results = [near_equality_accuracy_for_sigma(block, sigma, REPLICATES) for sigma in sigmas]
+    results = [near_equality_accuracy_for_sigma(sigma, REPLICATES) for sigma in sigmas]
 
     fig, ax = plt.subplots()
     ax.plot(sigmas, results, c='blue', label='near_equals() performance')
@@ -401,4 +412,8 @@ def plot_near_equality_power():
 
 
 if __name__ == '__main__':
+    import matplotlib
+    matplotlib.use('TkAgg')
+    from matplotlib import pyplot as plt
+
     plot_near_equality_power()

--- a/src/python/utils/vision.py
+++ b/src/python/utils/vision.py
@@ -1,0 +1,404 @@
+from __future__ import division
+import itertools
+from random import Random
+from copy import copy
+
+import numpy as np
+import networkx as nx
+import matplotlib
+matplotlib.use('TkAgg')
+from matplotlib import pyplot as plt
+
+
+SIMILARITY_THRESHOLD = 0.9
+
+
+class GenericBlock(object):
+    """Python Block object with handy geometric functions"""
+    KEYS = ['signature', 'x', 'y', 'width', 'height']
+    """Properties to use for calculating hashcode and equality, override in subclasses"""
+
+    def __init__(self, signature, x, y, width, height):
+        self.signature = signature
+        self.x = x
+        self.y = y
+        self.width = width
+        self.height = height
+
+        self.__key = None
+
+    @property
+    def _key(self):
+        if self.__key is None:
+            self.__key = tuple(getattr(self, key) for key in self.KEYS)
+        return self.__key
+
+    @property
+    def xmin(self):
+        return self.x
+
+    @property
+    def ymin(self):
+        return self.y
+
+    @property
+    def xmax(self):
+        return self.x + self.width
+
+    @property
+    def ymax(self):
+        return self.y + self.height
+
+    @property
+    def area(self):
+        return self.width * self.height
+
+    @property
+    def aspect_ratio(self):
+        return self.width / self.height
+
+    def __repr__(self):
+        return '{}({{{}}})'.format(
+            type(self).__name__,
+            ', '.join('{}={}'.format(key, getattr(self, key)) for key in self.KEYS)
+        )
+
+    def __eq__(self, other):
+        return self._key == other._key
+
+    def __hash__(self):
+        return hash(self._key)
+
+    def __lt__(self, other):
+        return (self.x, self.y) < (other.xmin, other.ymin)
+
+    def intersection_area(self, other, check_sig=False):
+        """
+        Find the area of the intersection between this block and another block.
+        
+        Parameters
+        ----------
+        other : GenericBlock
+        check_sig
+
+        Returns
+        -------
+        int
+        """
+        if check_sig and self.signature != other.signature:
+            return 0
+
+        x_overlap = max(0, min(self.xmax, other.xmax) - max(self.x, other.x))
+        y_overlap = max(0, min(self.ymax, other.ymax) - max(self.y, other.y))
+        return x_overlap * y_overlap
+
+    def intersects(self, other, check_sig=False):
+        """Return whether this block intersects with the other block"""
+        return bool(self.intersection_area(other, check_sig))
+
+    def nearly_equals(self, other, threshold=SIMILARITY_THRESHOLD):
+        """
+        Return True if the intersection area of the two blocks is greater than the threshold proportion of the larger 
+        block's area.
+        
+        Parameters
+        ----------
+        other
+        threshold : float
+            < 0 if everything is equal to everything
+
+        Returns
+        -------
+        bool
+        """
+        return self.signature == other.signature and self.intersection_ppn(other) >= threshold
+
+    def intersection_ppn(self, other, check_sig=False):
+        """
+        Find what proportion of the larger block's area intersects with the smaller block.
+         
+        Parameters
+        ----------
+        other : GenericBlock
+        check_sig
+
+        Returns
+        -------
+        float
+            0 - 1
+        """
+        if check_sig and self.signature != other.signature:
+            return 0
+        area = self.intersection_area(other)
+        return area / max(self.area, other.area)
+
+    @classmethod
+    def merge_blocks(cls, *blocks):
+        """
+        CLASS METHOD
+        
+        Given any number of blocks, return a block which has the mean size and position of all of them.
+        
+        Parameters
+        ----------
+        blocks
+
+        Returns
+        -------
+        GenericBlock
+        """
+        signatures = set()
+        xs, ys, widths, heights = [], [], [], []
+
+        for block in blocks:
+            signatures.add(block.signature)
+            xs.append(block.xmin)
+            ys.append(block.ymin)
+            widths.append(block.width)
+            heights.append(block.height)
+
+        assert len(signatures) == 1
+
+        x, y, width, height = np.mean([xs, ys, widths, heights], axis=1)
+        return cls(signatures.pop(), x, y, width, height)
+
+
+class PixyBlock(GenericBlock):
+    """GenericBlock subclass with methods for construction from a ctypes-backed Blocks object"""
+
+    KEYS = GenericBlock.KEYS + ['type', 'angle']
+
+    def __init__(self, signature, x, y, width, height, type_=0, angle=0):
+        super(PixyBlock, self).__init__(
+            signature, x, y, width, height
+        )
+        self.type = type_  # todo: what is this?
+        self.angle = angle  # todo: what is this?
+
+    @classmethod
+    def from_ctypes(cls, ctypes_block):
+        """
+        Instantiate PixyBlock from a ctypes-backed Blocks object
+        
+        Parameters
+        ----------
+        ctypes_block
+
+        Returns
+        -------
+        PixyBlock
+        """
+        return cls(
+            ctypes_block.signature,
+            ctypes_block.x, ctypes_block.y,
+            ctypes_block.width, ctypes_block.height,
+            ctypes_block.type, ctypes_block.angle
+        )
+
+    @classmethod
+    def from_ctypes_array(cls, ctypes_blocks, count):
+        """
+        Instantiate a list of PixyBlock objects from a ctypes-backed BlocksArray
+        
+        Parameters
+        ----------
+        ctypes_blocks
+        count
+
+        Returns
+        -------
+        list of PixyBlock
+        """
+        return [cls.from_ctypes(ctypes_blocks[i]) for i in range(count)]
+
+    @classmethod
+    def merge_blocks(cls, *blocks):
+        """
+        Given any number of other blocks, return a block which has the mean size and position of all of them.
+
+        Parameters
+        ----------
+        blocks
+
+        Returns
+        -------
+        GenericBlock
+        """
+        signatures = set()
+        xs, ys, widths, heights = [], [], [], []  # todo: add types and angles after figuring out what they do
+        for block in blocks:
+            signatures.add(block.signature)
+            xs.append(block.xmin)
+            ys.append(block.ymin)
+            widths.append(block.width)
+            heights.append(block.height)
+
+        assert len(signatures) == 1
+
+        x, y, width, height = np.mean([xs, ys, widths, heights], axis=1)
+        return cls(signatures.pop(), x, y, width, height)
+
+
+def nearly_equal_pairs(blocks_1, blocks_2=None, threshold=SIMILARITY_THRESHOLD):
+    """
+    Find pairs of blocks which are likely to be the same object.
+    
+    If blocks_2 is None (default), all pairs within blocks_1 will be tested for near-equality. Otherwise, 
+    pairs of objects from blocks_1, and blocks_2 will be tested.
+    
+    Parameters
+    ----------
+    blocks_1
+    blocks_2
+    threshold
+
+    Returns
+    -------
+
+    """
+    out = set()
+    if blocks_2 is None:
+        this_that = itertools.combinations(blocks_1, 2)
+    else:
+        this_that = itertools.product(blocks_1, blocks_2)
+
+    for this, that in this_that:
+        if this.nearly_equals(that, threshold):
+            out.add((this, that))
+
+    return out
+
+
+def merge_similar_blocks(blocks_1, blocks_2=None, block_constructor=GenericBlock):
+    g = nx.Graph()
+    g.add_nodes_from(itertools.chain(blocks_1, blocks_2) if blocks_2 else blocks_1)
+    g.add_edges_from(nearly_equal_pairs(blocks_1, blocks_2, threshold=SIMILARITY_THRESHOLD))
+    out = set()
+
+    for component in nx.connected_components(g):
+        if len(component) == 1:
+            out.add(component.pop())
+        else:
+            out.add(block_constructor.merge_blocks(*component))
+
+    return out
+
+
+class Scene(object):
+    """Object describing a set of blocks"""
+
+    def __init__(self, blocks, block_constructor=GenericBlock):
+        """
+        
+        Parameters
+        ----------
+        blocks : sequence
+            Python block objects
+        block_constructor : type
+        """
+        self.blocks = set(blocks)
+        self.block_constructor = block_constructor
+
+    @classmethod
+    def from_ctypes_array(cls, pixy_blocks, count):
+        """
+        Instantiate scene directly from pixy camera output
+        
+        Parameters
+        ----------
+        pixy_blocks : BlocksArray
+        count
+
+        Returns
+        -------
+        Scene
+        """
+        blocks = PixyBlock.from_ctypes_array(pixy_blocks, count)
+        return cls(blocks, PixyBlock)
+
+    def merge(self, other):
+        """
+        Union two scenes, merging any similar blocks.
+        
+        Parameters
+        ----------
+        other : Scene
+
+        Returns
+        -------
+        Scene
+        """
+        return Scene(merge_similar_blocks(self.blocks, other.blocks, self.block_constructor), self.block_constructor)
+
+    def diff(self, other):
+        """
+        Diff two scenes, returning a pair of sets. The first element contains blocks which exist in the other scene 
+        without a likely counterpart in this scene; the second element contains blocks which exist in this 
+        scene without a likely counterpart in the other scene.
+        
+        Parameters
+        ----------
+        other : Scene
+
+        Returns
+        -------
+        tuple
+            (new_blocks, disappeared_blocks)
+        """
+        ppns = nearly_equal_pairs(self.blocks, other.blocks, threshold=SIMILARITY_THRESHOLD)
+        disappeared_blocks = set(self.blocks)
+        new_blocks = set(other.blocks)
+        for this_block, that_block in ppns:
+            disappeared_blocks.remove(this_block)
+            new_blocks.remove(that_block)
+
+        return new_blocks, disappeared_blocks
+
+
+# DIAGNOSTICS
+
+class BlockJitterer(object):
+    def __init__(self, sigma, seed=1, constructor=GenericBlock):
+        self.random = Random(seed)
+        self.sigma = sigma
+        self.constructor = constructor
+
+    def jitter_blocks(self, block, count=1):
+        return (self._jitter_block(block) for _ in range(count))
+
+    def _jitter_block(self, block):
+        new_block = copy(block)
+        new_block.x += self.random.gauss(0, self.sigma)
+        new_block.y += self.random.gauss(0, self.sigma)
+        new_block.width += self.random.gauss(0, self.sigma)
+        new_block.height += self.random.gauss(0, self.sigma)
+        return new_block
+
+
+def near_equality_accuracy_for_sigma(block, sigma, replicates):
+    jitterer = BlockJitterer(sigma=sigma, seed=1)
+    return sum(block.nearly_equals(jittered) for jittered in jitterer.jitter_blocks(block, replicates)) / replicates
+
+
+def plot_near_equality_power():
+    TARGET_SIGMA = 0.05
+    TARGET_CONFIDENCE = 0.95
+    REPLICATES = 500
+
+    block = GenericBlock(1, 0, 0, 1, 1)
+
+    sigmas = np.linspace(0, TARGET_SIGMA * 2, 101, True)
+    results = [near_equality_accuracy_for_sigma(block, sigma, REPLICATES) for sigma in sigmas]
+
+    fig, ax = plt.subplots()
+    ax.plot(sigmas, results, c='blue', label='near_equals() performance')
+    ax.axvline(TARGET_SIGMA, c='red', label='Target $\sigma$, {}% of side length'.format(TARGET_SIGMA*100))
+    ax.axhline(TARGET_CONFIDENCE, c='green', label='Target confidence, {}% correct'.format(TARGET_CONFIDENCE*100))
+    ax.set_xlabel('Standard deviation of location, size ($\sigma$)')
+    ax.set_ylabel('Proportion correct')
+    plt.legend()
+    plt.show()
+
+
+if __name__ == '__main__':
+    plot_near_equality_power()

--- a/src/python/utils/vision.py
+++ b/src/python/utils/vision.py
@@ -32,17 +32,20 @@ near-equality can be found (current implementation uses a threshold intersection
 `SIMILARITY_THRESHOLD`, but this can change)
 >>> is_probably_same_block = block.nearly_equals(block2)  # boolean
 
-# Scene is a wrapper for a set of PixyBlocks. There are three ways to instantiate it (but you should use the first)
+Scene is a wrapper for a set of PixyBlocks. There are three ways to instantiate it (but you should use the first)
 >>> scene1 = Scene.from_pixy()  # get PixyBlocks directly from camera
 >>> scene2 = Scene(pixyblock_list, PixyBlock)  # if you already have a list of PixyBlock objects
 >>> count = pixy.pixy_get_blocks(BLOCK_BUFFER_SIZE, block_buffer)
 >>> scene3 = Scene.from_ctypes_array(block_buffer, count)  # the long way round
 
-# scenes can be merged (e.g. take 2 pictures of the same thing, merge any objects which are nearly equal)
+Scenes can be merged (e.g. take 2 pictures of the same thing, merge any objects which are nearly equal)
 >>> merged_scene = scene1.merge_with(scene2)
 
-# scenes can be diffed (e.g. take a picture, fire a shot, take another picture - has anything changed?)
+Scenes can be diffed (e.g. take a picture, fire a shot, take another picture - has anything changed?)
 >>> new_blocks, disappeared_blocks = scene1.diff(scene2)
+
+The biggest block (for example) can be found in a normal pythonic way
+>>> largest_block = max(scene1, key=lambda block: block.area)
 """
 
 from __future__ import division
@@ -365,6 +368,9 @@ class Scene(object):
         """
         self.blocks = set(blocks)
         self.block_constructor = block_constructor
+
+    def __iter__(self):
+        return iter(self.blocks)
 
     @classmethod
     def from_pixy(cls):


### PR DESCRIPTION
Related to #30 

A draft implementation of object permanence, including unit tests so that we can rapidly check that a different algorithm works, a diagnostic function for checking how different algorithms/thresholds perform, and fully-functioning python classes for both the signature block, and a scene of multiple blocks - using these will mean we don't need to mess about with allocated memory and C being weird and so on, and should move a lot of calculations which would otherwise need to be done in several places, into one canonical implementation.

Blocks can have their intersections with other blocks checked easily; Scenes can be merged or diff'd (this just uses the `nearly_equal` method on the parent GenericBlock, so it's very easy to change). Scenes and PixyBlocks can both be instantiated straight from the ctypes objects, for your convenience.

I've tried to design it such that it's as little effort as possible to change the actual object permanence algorithm (which, as you can see in https://github.com/clbarnes/pixybattle/compare/object_permanence?expand=1#diff-8dc1a65fa311b437edf0f11398a41aa7R96 is extremely simple). The algorithm can change, that's fine. That is the point of all this architecture. If a new algorithm fails, we'll know about it straight away because of the unit tests (which are run with `pytest`).

Still to do:

- [ ] I don't know what the `type` or `angle` attributes are on the ctypes Blocks object - do @yinan-wan or @zqwei know? When I find out, I need to change `PixyBlock.merge_blocks()`.
- [ ] PixyBlock needs to handle the camera angle too - it'll just take the raw angle as a parameter and then transform that into (x, y) space and add it to the coordinates. That way blocks gathered from multiple camera angles can be added to the same scene (so long as the robot's wheels don't move).